### PR TITLE
Optimize to consume 32 -bits in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX = dpcpp
-CXXFLAGS = -std=c++20 -Wall -Weverything -Wno-c++98-compat -Wno-c++98-c++11-compat-binary-literal
+CXXFLAGS = -std=c++20 -Wall -Weverything -Wno-c++98-compat -Wno-c++98-c++11-compat-binary-literal -Wno-c++98-compat-pedantic
 OPTFLAGS = -O3
 IFLAGS = -I ./include
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Accelerating Acorn: A Lightweight Authenticated Cipher
 
 ## Overview
 
-After implementing `ascon` --- a fast, lightweight cryptographic suite, implementing authenticated encryption ( read AEAD ) & cryptographically secure hashing, I decided to take up another finalist ( in lightweight application category ) of CAESER AEAD competition --- `acorn` : a lightweight authenticated cipher suite.
+After implementing `ascon` --- a fast, lightweight cryptographic suite, implementing authenticated encryption ( read AEAD ) & cryptographically secure hashing, I decided to take up another winner ( in lightweight application category ) of CAESER AEAD competition --- `acorn` : a lightweight authenticated cipher suite.
 
 > Read more about AEAD [here](https://en.wikipedia.org/wiki/Authenticated_encryption)
 
@@ -40,7 +40,7 @@ After that boolean flag should be tested for truthfulness, if it doesn't pass th
 
 If any of authentication tag/ encrypted bytes/ associated data bytes are mutated ( even a single bit flipped ), verified decryption process should fail.
 
-Here I keep a C++ header-only library ( with C++20 features ), implementing **Acorn128 v3**, which can be compiled down to CPU/ GPGPU ( using SYCL kernels ) executable code.
+Here I keep a C++ header-only library, implementing **Acorn128 v3**, which can be compiled down to CPU/ GPGPU ( using SYCL kernels ) executable code.
 
 - How to test/ benchmark/ use `acorn` ?
   - Can be found below.
@@ -84,7 +84,7 @@ cmake version 3.16.3
 
 - For benchmarking Acorn128 implementation, you must have `google-benchmark` globally installed; see [here](https://github.com/google/benchmark/tree/60b16f1#installation)
 
-- Make sure you've C++ standard library, implementing `C++20` specification, installed ( as this library uses C++20 features )
+- Make sure you've C++ standard library, implementing `C++20` specification, installed
 
 ## Testing
 
@@ -101,10 +101,12 @@ This will run two kinds of tests
   - Associated data bytes
   - Encrypted data bytes
   - 128 -bit authentication tag
+  - 128 -bit public message nonce
+  - 128 -bit secret key
 
 ## Benchmarking
 
-For benchmarking authenticated encryption & verified decryption using Acorn128 cipher suite, run
+For benchmarking authenticated encryption & verified decryption of Acorn128 cipher suite, run
 
 > `google-benchmark` header files, source files & library must be globally installed !
 
@@ -113,7 +115,7 @@ make benchmark
 ```
 
 ```bash
-2022-04-05T05:46:33+00:00
+2022-04-13T13:30:10+00:00
 Running ./bench/a.out
 Run on (4 X 2300.14 MHz CPU s)
 CPU Caches:
@@ -121,17 +123,31 @@ CPU Caches:
   L1 Instruction 32 KiB (x2)
   L2 Unified 256 KiB (x2)
   L3 Unified 46080 KiB (x1)
-Load Average: 0.00, 0.00, 0.00
-------------------------------------------------------------------------
-Benchmark              Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------
-acorn_encrypt     692409 ns       692392 ns         1009 bytes_per_second=5.72982M/s items_per_second=1.44427k/s
-acorn_decrypt     697829 ns       697830 ns         1004 bytes_per_second=5.68518M/s items_per_second=1.43301k/s
+Load Average: 0.16, 0.15, 0.10
+----------------------------------------------------------------------------------
+Benchmark                        Time             CPU   Iterations UserCounters...
+----------------------------------------------------------------------------------
+acorn_encrypt_64B_32B         1593 ns         1593 ns       437893 bytes_per_second=57.4812M/s items_per_second=627.848k/s
+acorn_encrypt_128B_32B        1810 ns         1810 ns       391869 bytes_per_second=84.3073M/s items_per_second=552.516k/s
+acorn_encrypt_256B_32B        2178 ns         2178 ns       321253 bytes_per_second=126.09M/s items_per_second=459.08k/s
+acorn_encrypt_512B_32B        3075 ns         3075 ns       235572 bytes_per_second=168.713M/s items_per_second=325.199k/s
+acorn_encrypt_1024B_32B       4547 ns         4547 ns       153358 bytes_per_second=221.504M/s items_per_second=219.947k/s
+acorn_encrypt_2048B_32B       7704 ns         7704 ns        91038 bytes_per_second=257.49M/s items_per_second=129.807k/s
+acorn_encrypt_4096B_32B      13994 ns        13993 ns        50042 bytes_per_second=281.337M/s items_per_second=71.464k/s
+acorn_decrypt_64B_32B         1601 ns         1601 ns       436588 bytes_per_second=57.1972M/s items_per_second=624.746k/s
+acorn_decrypt_128B_32B        1811 ns         1811 ns       386671 bytes_per_second=84.2784M/s items_per_second=552.327k/s
+acorn_decrypt_256B_32B        2238 ns         2238 ns       314230 bytes_per_second=122.705M/s items_per_second=446.755k/s
+acorn_decrypt_512B_32B        3073 ns         3073 ns       228023 bytes_per_second=168.812M/s items_per_second=325.391k/s
+acorn_decrypt_1024B_32B       4744 ns         4744 ns       147653 bytes_per_second=212.276M/s items_per_second=210.783k/s
+acorn_decrypt_2048B_32B       8085 ns         8085 ns        86586 bytes_per_second=245.355M/s items_per_second=123.689k/s
+acorn_decrypt_4096B_32B      14770 ns        14770 ns        47390 bytes_per_second=266.536M/s items_per_second=67.7043k/s
 ```
+
+> In above console output, `acorn_{encrypt|decrypt}_X_Y` denotes for testing encrypt/ decrypt routine of Acorn128 cipher suite plain text/ cipher text length is X -bytes while associated data length is Y -bytes. You'll notice Y = 32 -bytes always, while X is varied !
 
 ## Usage
 
-`acorn` is a header-only C++ library ( using C++20 features ), using it is as easy as including header file `include/acorn.hpp` in your program & adding `./include` directory to your `INCLUDE_PATH` during compilation. 
+`acorn` is a header-only C++ library, using it is as easy as including header file `include/acorn.hpp` in your program & adding `./include` directory to your `INCLUDE_PATH` during compilation. 
 
 - **A**uthenticated **E**ncryption with **A**ssociated **D**ata related routines that you'll be generally interested in, are kept in `acorn::` namespace.
 

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -3,44 +3,44 @@
 #include <benchmark/benchmark.h>
 #include <string.h>
 
-#define CT_LEN 4096ul // bytes; >= 0
-#define DATA_LEN 64ul // bytes; >= 0
-#define KNT_LEN 16ul  // bytes; secret key/ nonce/ auth tag
+#define KNT_LEN 16u // secret key/ nonce/ tag length in bytes
 
 // Benchmark Acorn-128 authenticated encryption routine
 static void
-acorn_encrypt(benchmark::State& state)
+acorn_encrypt(benchmark::State& state,
+              const size_t ct_len,
+              const size_t data_len)
 {
   // acquire memory resources
-  uint8_t* text = static_cast<uint8_t*>(malloc(CT_LEN));
-  uint8_t* enc = static_cast<uint8_t*>(malloc(CT_LEN));
-  uint8_t* data = static_cast<uint8_t*>(malloc(DATA_LEN));
+  uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));
+  uint8_t* enc = static_cast<uint8_t*>(malloc(ct_len));
+  uint8_t* data = static_cast<uint8_t*>(malloc(data_len));
   uint8_t* key = static_cast<uint8_t*>(malloc(KNT_LEN));
   uint8_t* nonce = static_cast<uint8_t*>(malloc(KNT_LEN));
   uint8_t* tag = static_cast<uint8_t*>(malloc(KNT_LEN));
 
   // random plain text bytes
-  random_data(text, CT_LEN);
+  random_data(text, ct_len);
   // random associated data bytes
-  random_data(data, DATA_LEN);
+  random_data(data, data_len);
   // random secret key ( = 128 -bit )
   random_data(key, KNT_LEN);
   // random public message nonce ( = 128 -bit )
   random_data(nonce, KNT_LEN);
 
-  memset(enc, 0, CT_LEN);
+  memset(enc, 0, ct_len);
   memset(tag, 0, KNT_LEN);
 
   size_t itr = 0;
   for (auto _ : state) {
-    acorn::encrypt(key, nonce, text, CT_LEN, data, DATA_LEN, enc, tag);
+    acorn::encrypt(key, nonce, text, ct_len, data, data_len, enc, tag);
 
     benchmark::DoNotOptimize(enc);
     benchmark::DoNotOptimize(tag);
     benchmark::DoNotOptimize(itr++);
   }
 
-  state.SetBytesProcessed(static_cast<int64_t>((DATA_LEN + CT_LEN) * itr));
+  state.SetBytesProcessed(static_cast<int64_t>((data_len + ct_len) * itr));
   state.SetItemsProcessed(static_cast<int64_t>(itr));
 
   // deallocate all resources
@@ -54,44 +54,46 @@ acorn_encrypt(benchmark::State& state)
 
 // Benchmark Acorn-128 verified decryption routine
 static void
-acorn_decrypt(benchmark::State& state)
+acorn_decrypt(benchmark::State& state,
+              const size_t ct_len,
+              const size_t data_len)
 {
   // acquire memory resources
-  uint8_t* text = static_cast<uint8_t*>(malloc(CT_LEN));
-  uint8_t* enc = static_cast<uint8_t*>(malloc(CT_LEN));
-  uint8_t* dec = static_cast<uint8_t*>(malloc(CT_LEN));
-  uint8_t* data = static_cast<uint8_t*>(malloc(DATA_LEN));
+  uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));
+  uint8_t* enc = static_cast<uint8_t*>(malloc(ct_len));
+  uint8_t* dec = static_cast<uint8_t*>(malloc(ct_len));
+  uint8_t* data = static_cast<uint8_t*>(malloc(data_len));
   uint8_t* key = static_cast<uint8_t*>(malloc(KNT_LEN));
   uint8_t* nonce = static_cast<uint8_t*>(malloc(KNT_LEN));
   uint8_t* tag = static_cast<uint8_t*>(malloc(KNT_LEN));
 
   // random plain text bytes
-  random_data(text, CT_LEN);
+  random_data(text, ct_len);
   // random associated data bytes
-  random_data(data, DATA_LEN);
+  random_data(data, data_len);
   // random secret key ( = 128 -bit )
   random_data(key, KNT_LEN);
   // random public message nonce ( = 128 -bit )
   random_data(nonce, KNT_LEN);
 
-  memset(enc, 0, CT_LEN);
-  memset(dec, 0, CT_LEN);
+  memset(enc, 0, ct_len);
+  memset(dec, 0, ct_len);
   memset(tag, 0, KNT_LEN);
 
   // compute encrypted text & authentication tag
-  acorn::encrypt(key, nonce, text, CT_LEN, data, DATA_LEN, enc, tag);
+  acorn::encrypt(key, nonce, text, ct_len, data, data_len, enc, tag);
 
   size_t itr = 0;
   for (auto _ : state) {
     using namespace benchmark;
     using namespace acorn;
 
-    DoNotOptimize(decrypt(key, nonce, tag, enc, CT_LEN, data, DATA_LEN, dec));
+    DoNotOptimize(decrypt(key, nonce, tag, enc, ct_len, data, data_len, dec));
     DoNotOptimize(dec);
     DoNotOptimize(itr++);
   }
 
-  state.SetBytesProcessed(static_cast<int64_t>((DATA_LEN + CT_LEN) * itr));
+  state.SetBytesProcessed(static_cast<int64_t>((data_len + ct_len) * itr));
   state.SetItemsProcessed(static_cast<int64_t>(itr));
 
   // deallocate all resources
@@ -104,9 +106,136 @@ acorn_decrypt(benchmark::State& state)
   free(tag);
 }
 
+// Benchmark Acorn-128 encrypt routine with 64 -bytes plain text & 32 -bytes
+// associated data
+static void
+acorn_encrypt_64B_32B(benchmark::State& state)
+{
+  acorn_encrypt(state, 64ul, 32ul);
+}
+
+// Benchmark Acorn-128 encrypt routine with 128 -bytes plain text & 32 -bytes
+// associated data
+static void
+acorn_encrypt_128B_32B(benchmark::State& state)
+{
+  acorn_encrypt(state, 128ul, 32ul);
+}
+
+// Benchmark Acorn-128 encrypt routine with 256 -bytes plain text & 32 -bytes
+// associated data
+static void
+acorn_encrypt_256B_32B(benchmark::State& state)
+{
+  acorn_encrypt(state, 256ul, 32ul);
+}
+
+// Benchmark Acorn-128 encrypt routine with 512 -bytes plain text & 32 -bytes
+// associated data
+static void
+acorn_encrypt_512B_32B(benchmark::State& state)
+{
+  acorn_encrypt(state, 512ul, 32ul);
+}
+
+// Benchmark Acorn-128 encrypt routine with 1024 -bytes plain text & 32 -bytes
+// associated data
+static void
+acorn_encrypt_1024B_32B(benchmark::State& state)
+{
+  acorn_encrypt(state, 1024ul, 32ul);
+}
+
+// Benchmark Acorn-128 encrypt routine with 2048 -bytes plain text & 32 -bytes
+// associated data
+static void
+acorn_encrypt_2048B_32B(benchmark::State& state)
+{
+  acorn_encrypt(state, 2048ul, 32ul);
+}
+
+// Benchmark Acorn-128 encrypt routine with 4096 -bytes plain text & 32 -bytes
+// associated data
+static void
+acorn_encrypt_4096B_32B(benchmark::State& state)
+{
+  acorn_encrypt(state, 4096ul, 32ul);
+}
+
+// Benchmark Acorn-128 decrypt routine with 64 -bytes cipher text & 32 -bytes
+// associated data
+static void
+acorn_decrypt_64B_32B(benchmark::State& state)
+{
+  acorn_decrypt(state, 64ul, 32ul);
+}
+
+// Benchmark Acorn-128 decrypt routine with 128 -bytes cipher text & 32 -bytes
+// associated data
+static void
+acorn_decrypt_128B_32B(benchmark::State& state)
+{
+  acorn_decrypt(state, 128ul, 32ul);
+}
+
+// Benchmark Acorn-128 decrypt routine with 256 -bytes cipher text & 32 -bytes
+// associated data
+static void
+acorn_decrypt_256B_32B(benchmark::State& state)
+{
+  acorn_decrypt(state, 256ul, 32ul);
+}
+
+// Benchmark Acorn-128 decrypt routine with 512 -bytes cipher text & 32 -bytes
+// associated data
+static void
+acorn_decrypt_512B_32B(benchmark::State& state)
+{
+  acorn_decrypt(state, 512ul, 32ul);
+}
+
+// Benchmark Acorn-128 decrypt routine with 1024 -bytes cipher text & 32 -bytes
+// associated data
+static void
+acorn_decrypt_1024B_32B(benchmark::State& state)
+{
+  acorn_decrypt(state, 1024ul, 32ul);
+}
+
+// Benchmark Acorn-128 decrypt routine with 2048 -bytes cipher text & 32 -bytes
+// associated data
+static void
+acorn_decrypt_2048B_32B(benchmark::State& state)
+{
+  acorn_decrypt(state, 2048ul, 32ul);
+}
+
+// Benchmark Acorn-128 decrypt routine with 4096 -bytes cipher text & 32 -bytes
+// associated data
+static void
+acorn_decrypt_4096B_32B(benchmark::State& state)
+{
+  acorn_decrypt(state, 4096ul, 32ul);
+}
+
 // register for benchmarking
-BENCHMARK(acorn_encrypt);
-BENCHMARK(acorn_decrypt);
+//
+// Note, associated data size is kept constant for all benchmaark cases !
+BENCHMARK(acorn_encrypt_64B_32B);
+BENCHMARK(acorn_encrypt_128B_32B);
+BENCHMARK(acorn_encrypt_256B_32B);
+BENCHMARK(acorn_encrypt_512B_32B);
+BENCHMARK(acorn_encrypt_1024B_32B);
+BENCHMARK(acorn_encrypt_2048B_32B);
+BENCHMARK(acorn_encrypt_4096B_32B);
+
+BENCHMARK(acorn_decrypt_64B_32B);
+BENCHMARK(acorn_decrypt_128B_32B);
+BENCHMARK(acorn_decrypt_256B_32B);
+BENCHMARK(acorn_decrypt_512B_32B);
+BENCHMARK(acorn_decrypt_1024B_32B);
+BENCHMARK(acorn_decrypt_2048B_32B);
+BENCHMARK(acorn_decrypt_4096B_32B);
 
 // main function to make it executable
 BENCHMARK_MAIN();

--- a/include/acorn.hpp
+++ b/include/acorn.hpp
@@ -25,43 +25,11 @@ encrypt(const uint8_t* const __restrict key,   // 128 -bit secret key
         uint8_t* const __restrict tag          // 128 -bit authentication tag
 )
 {
-  // 293 -bit Acorn-128 state
-  bool state[acorn_utils::STATE_BIT_LEN];
-
-  // 128 -bit secret key as bit sequence
-  bool key_[128];
-#pragma unroll 16
-  for (size_t i = 0; i < 16; i++) {
-    const size_t off = i << 3;
-
-    key_[off + 0] = acorn_utils::bit_at<0>(key[i]);
-    key_[off + 1] = acorn_utils::bit_at<1>(key[i]);
-    key_[off + 2] = acorn_utils::bit_at<2>(key[i]);
-    key_[off + 3] = acorn_utils::bit_at<3>(key[i]);
-    key_[off + 4] = acorn_utils::bit_at<4>(key[i]);
-    key_[off + 5] = acorn_utils::bit_at<5>(key[i]);
-    key_[off + 6] = acorn_utils::bit_at<6>(key[i]);
-    key_[off + 7] = acorn_utils::bit_at<7>(key[i]);
-  }
-
-  // 128 -bit public message nonce as bit sequence
-  bool nonce_[128];
-#pragma unroll 16
-  for (size_t i = 0; i < 16; i++) {
-    const size_t off = i << 3;
-
-    nonce_[off + 0] = acorn_utils::bit_at<0>(nonce[i]);
-    nonce_[off + 1] = acorn_utils::bit_at<1>(nonce[i]);
-    nonce_[off + 2] = acorn_utils::bit_at<2>(nonce[i]);
-    nonce_[off + 3] = acorn_utils::bit_at<3>(nonce[i]);
-    nonce_[off + 4] = acorn_utils::bit_at<4>(nonce[i]);
-    nonce_[off + 5] = acorn_utils::bit_at<5>(nonce[i]);
-    nonce_[off + 6] = acorn_utils::bit_at<6>(nonce[i]);
-    nonce_[off + 7] = acorn_utils::bit_at<7>(nonce[i]);
-  }
+  // 293 -bit Acorn-128 state, zero initialize
+  uint64_t state[acorn_utils::LFSR_CNT] = { 0ul };
 
   // see section 1.3.3
-  acorn_utils::initialize(state, key_, nonce_);
+  acorn_utils::initialize(state, key, nonce);
   // see section 1.3.4
   acorn_utils::process_associated_data(state, data, d_len);
   // see section 1.3.5
@@ -93,45 +61,13 @@ decrypt(const uint8_t* const __restrict key,    // 128 -bit secret key
         uint8_t* const __restrict text          // decrypted bytes
 )
 {
-  // 293 -bit Acorn-128 state
-  bool state[acorn_utils::STATE_BIT_LEN];
+  // 293 -bit Acorn-128 state, zero initialize
+  uint64_t state[acorn_utils::LFSR_CNT] = { 0ul };
   // 128 -bit authentication tag
   uint8_t tag_[16];
 
-  // 128 -bit secret key as bit sequence
-  bool key_[128];
-#pragma unroll 16
-  for (size_t i = 0; i < 16; i++) {
-    const size_t off = i << 3;
-
-    key_[off + 0] = acorn_utils::bit_at<0>(key[i]);
-    key_[off + 1] = acorn_utils::bit_at<1>(key[i]);
-    key_[off + 2] = acorn_utils::bit_at<2>(key[i]);
-    key_[off + 3] = acorn_utils::bit_at<3>(key[i]);
-    key_[off + 4] = acorn_utils::bit_at<4>(key[i]);
-    key_[off + 5] = acorn_utils::bit_at<5>(key[i]);
-    key_[off + 6] = acorn_utils::bit_at<6>(key[i]);
-    key_[off + 7] = acorn_utils::bit_at<7>(key[i]);
-  }
-
-  // 128 -bit public message nonce as bit sequence
-  bool nonce_[128];
-#pragma unroll 16
-  for (size_t i = 0; i < 16; i++) {
-    const size_t off = i << 3;
-
-    nonce_[off + 0] = acorn_utils::bit_at<0>(nonce[i]);
-    nonce_[off + 1] = acorn_utils::bit_at<1>(nonce[i]);
-    nonce_[off + 2] = acorn_utils::bit_at<2>(nonce[i]);
-    nonce_[off + 3] = acorn_utils::bit_at<3>(nonce[i]);
-    nonce_[off + 4] = acorn_utils::bit_at<4>(nonce[i]);
-    nonce_[off + 5] = acorn_utils::bit_at<5>(nonce[i]);
-    nonce_[off + 6] = acorn_utils::bit_at<6>(nonce[i]);
-    nonce_[off + 7] = acorn_utils::bit_at<7>(nonce[i]);
-  }
-
   // see section 1.3.3
-  acorn_utils::initialize(state, key_, nonce_);
+  acorn_utils::initialize(state, key, nonce);
   // see section 1.3.4
   acorn_utils::process_associated_data(state, data, d_len);
   // see section 1.3.5

--- a/include/acorn_utils.hpp
+++ b/include/acorn_utils.hpp
@@ -6,131 +6,344 @@ using size_t = std::size_t;
 // Acorn-128: A lightweight authenticated cipher ( read Authenticated Encryption
 // with Associated Data )
 //
-// Underlying basic functions such as updating Linear Shift
-// Feedback Register, initializing state register, processing associated data &
+// Underlying basic functions such as updating Linear Feedback Shift
+// Registers, initializing state register, processing associated data &
 // processing plain/ ciphered text is implemented under this namespace
 namespace acorn_utils {
 
-// Acorn state bit length, see section 1.3.1 of Acorn specification
+// Acorn state can be represented using 7 linear feedback shift registers,
+// making total of 293 -bits
+//
+// Due to unequal bit length of 7 LFSRs it takes seven 64 -bit unsigned integers
+// to represent whole 293 -bit state register
+//
+// See figure 1.1 of Acorn specification
 // https://competitions.cr.yp.to/round3/acornv3.pdf
-constexpr size_t STATE_BIT_LEN = 293ul;
+constexpr size_t LFSR_CNT = 7ul;
 
-// Acorn boolean function `maj`, taken from section 1.2.3 of Acorn specification
+// Maximum number which can be represented using 8 -bit unsigned interger
+constexpr uint8_t MAX_U8 = 0xffu;
+// Minimum number which can be represented using 8 -bit unsigned interger
+constexpr uint8_t MIN_U8 = 0u;
+
+// Maximum number which can be represented using 32 -bit unsigned interger
+constexpr uint32_t MAX_U32 = 0xffffffffu;
+// Minimum number which can be represented using 32 -bit unsigned interger
+constexpr uint32_t MIN_U32 = 0u;
+
+// Given an array of four big endian bytes this function interprets them as a
+// 32 -bit unsigned integer
+static inline uint32_t
+from_be_bytes(const uint8_t* const __restrict bytes)
+{
+  return (static_cast<uint32_t>(bytes[0]) << 24) |
+         (static_cast<uint32_t>(bytes[1]) << 16) |
+         (static_cast<uint32_t>(bytes[2]) << 8) |
+         (static_cast<uint32_t>(bytes[3]) << 0);
+}
+
+// Given a 32 -bit unsigned integer, this function interprets it as four big
+// endian bytes
+static inline void
+to_be_bytes(const uint32_t word, uint8_t* const __restrict bytes)
+{
+#pragma unroll 4
+  for (size_t i = 0; i < 4; i++) {
+    bytes[i] = static_cast<uint8_t>(word >> ((3u - i) << 3));
+  }
+}
+
+// Acorn function `maj`, taken from section 1.2.3 of Acorn specification
 // https://competitions.cr.yp.to/round3/acornv3.pdf
-static inline bool
-maj(const bool x, const bool y, const bool z)
+static inline uint64_t
+maj(const uint64_t x, const uint64_t y, const uint64_t z)
 {
   return (x & y) ^ (x & z) ^ (y & z);
 }
 
-// Acorn boolean function `ch`, taken from section 1.2.3 of Acorn specification
+// Acorn function `ch`, taken from section 1.2.3 of Acorn specification
 // https://competitions.cr.yp.to/round3/acornv3.pdf
-static inline bool
-ch(const bool x, const bool y, const bool z)
+static inline uint64_t
+ch(const uint64_t x, const uint64_t y, const uint64_t z)
 {
-  return (x & y) ^ (!x & z);
+  return (x & y) ^ (~x & z);
 }
 
-// Generate keystream bit, taken from section 1.3.2 of Acorn specification
+// Generate 32 keystream bits, taken from section 1.3.2 of Acorn specification
 // https://competitions.cr.yp.to/round3/acornv3.pdf
-static inline bool
-ksg128(const bool* const state // 293 -bit state
+static inline uint32_t
+ksg128(
+  const uint64_t* const state // 293 -bit state represented as seven u64 words
 )
 {
-  const bool b0 = maj(state[235], state[61], state[193]);
-  const bool b1 = ch(state[230], state[111], state[66]);
+  const uint64_t w235 = state[5] >> 5;
+  const uint64_t w111 = state[2] >> 4;
+  const uint64_t w66 = state[1] >> 5;
+  const uint64_t w12 = state[0] >> 12;
 
-  return state[12] ^ state[154] ^ b0 ^ b1;
+  const uint64_t w0 = maj(w235, state[1], state[4]);
+  const uint64_t w1 = ch(state[5], w111, w66);
+  return static_cast<uint32_t>(w12 ^ state[3] ^ w0 ^ w1);
 }
 
-// Compute feedback bit, using algorithm written in section 1.3.2 of Acorn
+// Compute 32 feedback bits, using algorithm written in section 1.3.2 of Acorn
 // specification https://competitions.cr.yp.to/round3/acornv3.pdf
-static inline bool
-fbk128(const bool* const state, // 293 -bit state
-       const bool ca,           // control bit `a`
-       const bool cb,           // control bit `b`
-       const bool ks            // key stream bit generated using `ksg128`
+static inline uint32_t
+fbk128(const uint64_t* const state, // 293 -bit state register
+       const uint32_t ca,           // 32 control bits `a`
+       const uint32_t cb,           // 32 control bits `b`
+       const uint32_t ks // 32 key stream bits generated using `ksg128`
 )
 {
-  const bool b0 = maj(state[244], state[23], state[160]);
+  const uint64_t w244 = state[5] >> 14;
+  const uint64_t w23 = state[0] >> 23;
+  const uint64_t w160 = state[3] >> 6;
+  const uint64_t w196 = state[4] >> 3;
 
-  return state[0] ^ !state[107] ^ b0 ^ (ca & state[196]) ^ (cb & ks);
+  const uint64_t w0 = maj(w244, w23, w160);
+  const uint64_t w1 = static_cast<uint64_t>(cb & ks);
+  const uint64_t w2 = w196 & static_cast<uint64_t>(ca);
+
+  const uint64_t w3 = w0 ^ w1 ^ w2;
+  return static_cast<uint32_t>(state[0] ^ ~state[2] ^ w3);
 }
 
-// Update state function, using algorithm written in section 1.3.2 of Acorn
+// Compute 8 feedback bits, using algorithm written in section 1.3.2 of Acorn
 // specification https://competitions.cr.yp.to/round3/acornv3.pdf
-static inline bool
-state_update_128(bool* const state, // 293 -bit state
-                 const bool m,      // message bit
-                 const bool ca,     // control bit `a`
-                 const bool cb      // control bit `b`
+static inline uint8_t
+fbk128(const uint64_t* const state, // 293 -bit state register
+       const uint8_t ca,            // 8 control bits `a`
+       const uint8_t cb,            // 8 control bits `b`
+       const uint8_t ks // 8 key stream bits generated using `ksg128`
 )
 {
+  const uint64_t w244 = state[5] >> 14;
+  const uint64_t w23 = state[0] >> 23;
+  const uint64_t w160 = state[3] >> 6;
+  const uint64_t w196 = state[4] >> 3;
+
+  const uint64_t w0 = maj(w244, w23, w160);
+  const uint64_t w1 = static_cast<uint64_t>(cb & ks);
+  const uint64_t w2 = w196 & static_cast<uint64_t>(ca);
+
+  const uint64_t w3 = w0 ^ w1 ^ w2;
+  return static_cast<uint8_t>(state[0] ^ ~state[2] ^ w3);
+}
+
+// Update state function operating on 32 -bits at a time, using algorithm
+// written in section 1.3.2 of Acorn specification
+// https://competitions.cr.yp.to/round3/acornv3.pdf
+//
+// Note, if you're attempting to decrypt text back, don't use this function for
+// state updation, see below.
+static inline uint32_t
+state_update_128(uint64_t* const state, // 293 -bit state
+                 const uint32_t m,      // 32 message bits
+                 const uint32_t ca,     // 32 control bits `a`
+                 const uint32_t cb      // 32 control bits `b`
+)
+{
+  const uint64_t w235 = state[5] >> 5;
+  const uint64_t w196 = state[4] >> 3;
+  const uint64_t w160 = state[3] >> 6;
+  const uint64_t w111 = state[2] >> 4;
+  const uint64_t w66 = state[1] >> 5;
+  const uint64_t w23 = state[0] >> 23;
+
   // step 1
-  state[289] = state[289] ^ state[235] ^ state[230];
-  state[230] = state[230] ^ state[196] ^ state[193];
-  state[193] = state[193] ^ state[160] ^ state[154];
-  state[154] = state[154] ^ state[111] ^ state[107];
-  state[107] = state[107] ^ state[66] ^ state[61];
-  state[61] = state[61] ^ state[23] ^ state[0];
+  state[6] ^= (state[5] ^ w235) & MAX_U32;
+  state[5] ^= (state[4] ^ w196) & MAX_U32;
+  state[4] ^= (state[3] ^ w160) & MAX_U32;
+  state[3] ^= (state[2] ^ w111) & MAX_U32;
+  state[2] ^= (state[1] ^ w66) & MAX_U32;
+  state[1] ^= (state[0] ^ w23) & MAX_U32;
   // step 2
-  const bool ks = ksg128(state); // key stream bit
+  const uint32_t ks = ksg128(state); // 32 key stream bits
   // step 3
-  const bool fb = fbk128(state, ca, cb, ks); // feedback bit
+  const uint32_t fb = fbk128(state, ca, cb, ks); // 32 feedback bits
   // step 4
-  for (size_t j = 0; j < STATE_BIT_LEN - 1ul; j++) {
-    state[j] = state[j + 1];
-  }
-  state[292] = fb ^ m;
+  state[6] ^= (static_cast<uint64_t>(fb ^ m) << 4);
+  state[0] = (state[0] >> 32) | ((state[1] & MAX_U32) << 29); // 61 - 32
+  state[1] = (state[1] >> 32) | ((state[2] & MAX_U32) << 14); // 46 - 32
+  state[2] = (state[2] >> 32) | ((state[3] & MAX_U32) << 15); // 47 - 32
+  state[3] = (state[3] >> 32) | ((state[4] & MAX_U32) << 7);  // 39 - 32
+  state[4] = (state[4] >> 32) | ((state[5] & MAX_U32) << 5);  // 37 - 32
+  state[5] = (state[5] >> 32) | ((state[6] & MAX_U32) << 27); // 59 - 32
+  state[6] = state[6] >> 32;
 
   return ks;
+}
+
+// Update state function operating on 32 -bits at a time, using algorithm
+// written in section 1.3.2 of Acorn specification
+// https://competitions.cr.yp.to/round3/acornv3.pdf
+//
+// Note, only use this function when `m_in` holds 32 encrypted bits & you want
+// to decrypt them back & keep in `m_out`
+//
+// Also note, this function doesn't return 32 key stream bits ( notice above
+// overloaded variant does ) because when decrypting bits ( that's when this
+// function is supposed to be invoked ) key stream bits won't be required
+// anymore as we've already recovered plain text inside this function
+static inline void
+state_update_128(
+  uint64_t* const __restrict state, // 293 -bit state
+  const uint32_t m_in,              // 32 encrypted message bits
+  uint32_t* const __restrict m_out, // 32 decrypted message bits ( result ! )
+  const uint32_t ca,                // 32 control bits `a`
+  const uint32_t cb                 // 32 control bits `b`
+)
+{
+  const uint64_t w235 = state[5] >> 5;
+  const uint64_t w196 = state[4] >> 3;
+  const uint64_t w160 = state[3] >> 6;
+  const uint64_t w111 = state[2] >> 4;
+  const uint64_t w66 = state[1] >> 5;
+  const uint64_t w23 = state[0] >> 23;
+
+  // step 1
+  state[6] ^= (state[5] ^ w235) & MAX_U32;
+  state[5] ^= (state[4] ^ w196) & MAX_U32;
+  state[4] ^= (state[3] ^ w160) & MAX_U32;
+  state[3] ^= (state[2] ^ w111) & MAX_U32;
+  state[2] ^= (state[1] ^ w66) & MAX_U32;
+  state[1] ^= (state[0] ^ w23) & MAX_U32;
+  // step 2
+  const uint32_t ks = ksg128(state); // 32 key stream bits
+  *m_out = m_in ^ ks;                // 32 decrypted bits
+  // step 3
+  const uint32_t fb = fbk128(state, ca, cb, ks); // 32 feedback bits
+  // step 4
+  state[6] ^= (static_cast<uint64_t>(fb ^ *m_out) << 4);
+  state[0] = (state[0] >> 32) | ((state[1] & MAX_U32) << 29); // 61 - 32
+  state[1] = (state[1] >> 32) | ((state[2] & MAX_U32) << 14); // 46 - 32
+  state[2] = (state[2] >> 32) | ((state[3] & MAX_U32) << 15); // 47 - 32
+  state[3] = (state[3] >> 32) | ((state[4] & MAX_U32) << 7);  // 39 - 32
+  state[4] = (state[4] >> 32) | ((state[5] & MAX_U32) << 5);  // 37 - 32
+  state[5] = (state[5] >> 32) | ((state[6] & MAX_U32) << 27); // 59 - 32
+  state[6] = state[6] >> 32;
+}
+
+// Update state function operating on 8 -bits at a time, using algorithm written
+// in section 1.3.2 of Acorn specification
+// https://competitions.cr.yp.to/round3/acornv3.pdf
+//
+// Note, if you're attempting to decrypt text back, don't use this function for
+// state updation, see below.
+static inline uint8_t
+state_update_128(uint64_t* const state, // 293 -bit state
+                 const uint8_t m,       // 8 message bits
+                 const uint8_t ca,      // 8 control bits `a`
+                 const uint8_t cb       // 8 control bits `b`
+)
+{
+  const uint64_t w235 = state[5] >> 5;
+  const uint64_t w196 = state[4] >> 3;
+  const uint64_t w160 = state[3] >> 6;
+  const uint64_t w111 = state[2] >> 4;
+  const uint64_t w66 = state[1] >> 5;
+  const uint64_t w23 = state[0] >> 23;
+
+  // step 1
+  state[6] ^= (state[5] ^ w235) & MAX_U8;
+  state[5] ^= (state[4] ^ w196) & MAX_U8;
+  state[4] ^= (state[3] ^ w160) & MAX_U8;
+  state[3] ^= (state[2] ^ w111) & MAX_U8;
+  state[2] ^= (state[1] ^ w66) & MAX_U8;
+  state[1] ^= (state[0] ^ w23) & MAX_U8;
+  // step 2
+  const uint8_t ks = static_cast<uint8_t>(ksg128(state)); // 8 key stream bits
+  // step 3
+  const uint8_t fb = fbk128(state, ca, cb, ks); // 8 feedback bits
+  // step 4
+  state[6] ^= (static_cast<uint64_t>(fb ^ m) << 4);
+  state[0] = (state[0] >> 8) | ((state[1] & MAX_U8) << 53); // 61 - 8
+  state[1] = (state[1] >> 8) | ((state[2] & MAX_U8) << 38); // 46 - 8
+  state[2] = (state[2] >> 8) | ((state[3] & MAX_U8) << 39); // 47 - 8
+  state[3] = (state[3] >> 8) | ((state[4] & MAX_U8) << 31); // 39 - 8
+  state[4] = (state[4] >> 8) | ((state[5] & MAX_U8) << 29); // 37 - 8
+  state[5] = (state[5] >> 8) | ((state[6] & MAX_U8) << 51); // 59 - 8
+  state[6] = state[6] >> 8;
+
+  return ks;
+}
+
+// Update state function operating on 8 -bits at a time, using algorithm written
+// in section 1.3.2 of Acorn specification
+// https://competitions.cr.yp.to/round3/acornv3.pdf
+//
+// Note, use this function for Acorn-128 state updation only when you're
+// attempting to decrypt 8 -bits. Encrypted input 8 -bits need to be present in
+// `m_in`, while decrypted output 8 -bits to live in `m_out`.
+//
+// Also note, this function doesn't need to return 8 key stream bits because
+// decrypted bits are recovered back from encrypted bits inside this function
+// body, so key steram bits are quite useless to function caller
+static inline void
+state_update_128(uint64_t* const __restrict state, // 293 -bit state
+                 const uint8_t m_in,               // 8 encrypted message bits
+                 uint8_t* const __restrict m_out,  // 8 decrypted message bits
+                 const uint8_t ca,                 // 8 control bits `a`
+                 const uint8_t cb                  // 8 control bits `b`
+)
+{
+  const uint64_t w235 = state[5] >> 5;
+  const uint64_t w196 = state[4] >> 3;
+  const uint64_t w160 = state[3] >> 6;
+  const uint64_t w111 = state[2] >> 4;
+  const uint64_t w66 = state[1] >> 5;
+  const uint64_t w23 = state[0] >> 23;
+
+  // step 1
+  state[6] ^= (state[5] ^ w235) & MAX_U8;
+  state[5] ^= (state[4] ^ w196) & MAX_U8;
+  state[4] ^= (state[3] ^ w160) & MAX_U8;
+  state[3] ^= (state[2] ^ w111) & MAX_U8;
+  state[2] ^= (state[1] ^ w66) & MAX_U8;
+  state[1] ^= (state[0] ^ w23) & MAX_U8;
+  // step 2
+  const uint8_t ks = static_cast<uint8_t>(ksg128(state)); // 8 key stream bits
+  *m_out = m_in ^ ks;                                     // 8 decrypted bits
+  // step 3
+  const uint8_t fb = fbk128(state, ca, cb, ks) ^ *m_out; // 8 feedback bits
+  // step 4
+  state[6] ^= (static_cast<uint64_t>(fb) << 4);
+  state[0] = (state[0] >> 8) | ((state[1] & MAX_U8) << 53); // 61 - 8
+  state[1] = (state[1] >> 8) | ((state[2] & MAX_U8) << 38); // 46 - 8
+  state[2] = (state[2] >> 8) | ((state[3] & MAX_U8) << 39); // 47 - 8
+  state[3] = (state[3] >> 8) | ((state[4] & MAX_U8) << 31); // 39 - 8
+  state[4] = (state[4] >> 8) | ((state[5] & MAX_U8) << 29); // 37 - 8
+  state[5] = (state[5] >> 8) | ((state[6] & MAX_U8) << 51); // 59 - 8
+  state[6] = state[6] >> 8;
 }
 
 // Initialize Acorn128 state, following algorithm specified in section 1.3.3 of
 // Acorn specification https://competitions.cr.yp.to/round3/acornv3.pdf
 static inline void
-initialize(bool* const __restrict state,     // 293 -bit state
-           const bool* const __restrict key, // 128 -bit secret key
-           const bool* const __restrict iv   // 128 -bit initialization vector
+initialize(
+  uint64_t* const __restrict state,    // 293 -bit state ( ensure zeroed ! )
+  const uint8_t* const __restrict key, // 128 -bit secret key
+  const uint8_t* const __restrict iv   // 128 -bit initialization vector
 )
 {
-  // step 1
-  for (size_t i = 0; i < STATE_BIT_LEN; i++) {
-    state[i] = false;
-  }
-
   // --- step 2, 3, 4 ---
-  for (size_t i = 0; i < 128; i++) {
-    state_update_128(state, key[i], true, true);
+  for (size_t i = 0; i < 4; i++) {
+    const uint32_t word = from_be_bytes(key + (i << 2));
+    state_update_128(state, word, MAX_U32, MAX_U32);
   }
 
-  for (size_t i = 0; i < 128; i++) {
-    state_update_128(state, iv[i], true, true);
+  for (size_t i = 0; i < 4; i++) {
+    const uint32_t word = from_be_bytes(iv + (i << 2));
+    state_update_128(state, word, MAX_U32, MAX_U32);
   }
 
-  state_update_128(state, key[0] ^ true, true, true);
+  state_update_128(state, from_be_bytes(key) ^ 0b1u, MAX_U32, MAX_U32);
 
-  for (size_t i = 1; i < 1536; i++) {
-    state_update_128(state, key[i % 128], true, true);
+  for (size_t i = 1; i < 48; i++) {
+    const uint32_t word = from_be_bytes(key + ((i & 3) << 2));
+    state_update_128(state, word, MAX_U32, MAX_U32);
   }
   // --- step 2, 3, 4 ---
-}
-
-// Compile time evaluation of template argument for `bit_at` routine; ensuring
-// requested bit position stays inside [0, 8)
-constexpr bool
-check_pos(const size_t pos)
-{
-  return pos < 8;
-}
-
-// Given 8 -bit unsigned integer, it selects requested bit value
-// for `pos` | 0 <= pos <= 7
-template<const size_t pos>
-static inline bool
-bit_at(const uint8_t byte) requires(check_pos(pos))
-{
-  return static_cast<bool>((byte >> pos) & static_cast<uint8_t>(0b1u));
 }
 
 // Processing the associated data bytes, following algorithm described in
@@ -138,36 +351,34 @@ bit_at(const uint8_t byte) requires(check_pos(pos))
 // https://competitions.cr.yp.to/round3/acornv3.pdf
 static inline void
 process_associated_data(
-  bool* const __restrict state,         // 293 -bit state
+  uint64_t* const __restrict state,     // 293 -bit state
   const uint8_t* const __restrict data, // associated data bytes
   const size_t data_len                 // len(data), can be >= 0
 )
 {
-  // line 1 of step 1; consume all associated data bits
-  for (size_t i = 0; i < data_len; i++) {
-    const uint8_t byte = data[i];
+  const size_t u32_cnt = data_len >> 2; // 32 -bit chunk count
+  const size_t u08_cnt = data_len % 4;  // remaining 8 -bit chunk count
 
-    // sequentially consume 8 -bits ( LSB to MSB ) per byte
-    state_update_128(state, bit_at<0>(byte), true, true);
-    state_update_128(state, bit_at<1>(byte), true, true);
-    state_update_128(state, bit_at<2>(byte), true, true);
-    state_update_128(state, bit_at<3>(byte), true, true);
-    state_update_128(state, bit_at<4>(byte), true, true);
-    state_update_128(state, bit_at<5>(byte), true, true);
-    state_update_128(state, bit_at<6>(byte), true, true);
-    state_update_128(state, bit_at<7>(byte), true, true);
+  // line 1 of step 1; consume all associated data bits
+  for (size_t i = 0; i < u32_cnt; i++) {
+    const uint32_t word = from_be_bytes(data + (i << 2));
+    state_update_128(state, word, MAX_U32, MAX_U32);
+  }
+
+  for (size_t i = 0; i < u08_cnt; i++) {
+    state_update_128(state, data[(u32_cnt << 2) + i], MAX_U8, MAX_U8);
   }
 
   // line 2 of step 1; append single `1` -bit
-  state_update_128(state, true, true, true);
+  state_update_128(state, 1u, MAX_U32, MAX_U32);
 
   // line 3 of step 1; append 255 `0` -bits
-  for (size_t i = 1; i < 128; i++) {
-    state_update_128(state, false, true, true);
+  for (size_t i = 0; i < 4; i++) {
+    state_update_128(state, 0u, MAX_U32, MAX_U32);
   }
 
-  for (size_t i = 128; i < 256; i++) {
-    state_update_128(state, false, false, true);
+  for (size_t i = 4; i < 8; i++) {
+    state_update_128(state, 0u, MIN_U32, MAX_U32);
   }
 }
 
@@ -175,74 +386,44 @@ process_associated_data(
 // location, following algorithm defined in section 1.3.5 of Acorn specification
 // https://competitions.cr.yp.to/round3/acornv3.pdf
 static inline void
-process_plain_text(bool* const __restrict state,         // 293 -bit state
+process_plain_text(uint64_t* const __restrict state,     // 293 -bit state
                    const uint8_t* const __restrict text, // plain text bytes
                    uint8_t* const __restrict cipher,     // ciphered data bytes
                    const size_t ct_len                   // can be >= 0
 )
 {
+  const size_t u32_cnt = ct_len >> 2; // 32 -bit chunk count
+  const size_t u08_cnt = ct_len % 4;  // remaining 8 -bit chunk count
+
   // line 1 of step 1; compute encrypted bits
   //
   // also see step 3 of algorithm defined in section 1.3.5
-  for (size_t i = 0; i < ct_len; i++) {
-    const uint8_t byte = text[i];
+  for (size_t i = 0; i < u32_cnt; i++) {
+    const uint32_t dec = from_be_bytes(text + (i << 2));
+    const uint32_t ks = state_update_128(state, dec, MAX_U32, MIN_U32);
 
-    const bool p0 = bit_at<0>(byte);
-    const bool ks0 = state_update_128(state, p0, true, false);
-    const bool c0 = ks0 ^ p0; // encrypted bit
+    const uint32_t enc = dec ^ ks;
+    to_be_bytes(enc, cipher + (i << 2));
+  }
 
-    const bool p1 = bit_at<1>(byte);
-    const bool ks1 = state_update_128(state, p1, true, false);
-    const bool c1 = ks1 ^ p1; // encrypted bit
+  for (size_t i = 0; i < u08_cnt; i++) {
+    const uint8_t dec = text[(u32_cnt << 2) + i];
+    const uint8_t ks = state_update_128(state, dec, MAX_U8, MIN_U8);
 
-    const bool p2 = bit_at<2>(byte);
-    const bool ks2 = state_update_128(state, p2, true, false);
-    const bool c2 = ks2 ^ p2; // encrypted bit
-
-    const bool p3 = bit_at<3>(byte);
-    const bool ks3 = state_update_128(state, p3, true, false);
-    const bool c3 = ks3 ^ p3; // encrypted bit
-
-    const bool p4 = bit_at<4>(byte);
-    const bool ks4 = state_update_128(state, p4, true, false);
-    const bool c4 = ks4 ^ p4; // encrypted bit
-
-    const bool p5 = bit_at<5>(byte);
-    const bool ks5 = state_update_128(state, p5, true, false);
-    const bool c5 = ks5 ^ p5; // encrypted bit
-
-    const bool p6 = bit_at<6>(byte);
-    const bool ks6 = state_update_128(state, p6, true, false);
-    const bool c6 = ks6 ^ p6; // encrypted bit
-
-    const bool p7 = bit_at<7>(byte);
-    const bool ks7 = state_update_128(state, p7, true, false);
-    const bool c7 = ks7 ^ p7; // encrypted bit
-
-    // from 8 encrypted bits prepare single ciphered byte
-    const uint8_t enc = static_cast<uint8_t>(static_cast<uint8_t>(c7) << 7) |
-                        static_cast<uint8_t>(static_cast<uint8_t>(c6) << 6) |
-                        static_cast<uint8_t>(static_cast<uint8_t>(c5) << 5) |
-                        static_cast<uint8_t>(static_cast<uint8_t>(c4) << 4) |
-                        static_cast<uint8_t>(static_cast<uint8_t>(c3) << 3) |
-                        static_cast<uint8_t>(static_cast<uint8_t>(c2) << 2) |
-                        static_cast<uint8_t>(static_cast<uint8_t>(c1) << 1) |
-                        static_cast<uint8_t>(c0);
-
-    // write 8 encrypted bits to allocated memory
-    cipher[i] = enc;
+    const uint8_t enc = dec ^ ks;
+    cipher[(u32_cnt << 2) + i] = enc;
   }
 
   // line 2 of step 1; append single `1` -bit
-  state_update_128(state, true, true, false);
+  state_update_128(state, 1u, MAX_U32, MIN_U32);
 
   // line 3 of step 1; append 255 `0` -bits
-  for (size_t i = 1; i < 128; i++) {
-    state_update_128(state, false, true, false);
+  for (size_t i = 0; i < 4; i++) {
+    state_update_128(state, 0u, MAX_U32, MIN_U32);
   }
 
-  for (size_t i = 128; i < 256; i++) {
-    state_update_128(state, false, false, false);
+  for (size_t i = 4; i < 8; i++) {
+    state_update_128(state, 0u, MIN_U32, MIN_U32);
   }
 }
 
@@ -251,122 +432,64 @@ process_plain_text(bool* const __restrict state,         // 293 -bit state
 // https://competitions.cr.yp.to/round3/acornv3.pdf
 static inline void
 process_cipher_text(
-  bool* const __restrict state,           // 293 -bit state
+  uint64_t* const __restrict state,       // 293 -bit state
   const uint8_t* const __restrict cipher, // ciphered data bytes
   uint8_t* const __restrict text,         // plain text bytes
   const size_t ct_len                     // can be >= 0
 )
 {
+  const size_t u32_cnt = ct_len >> 2; // 32 -bit chunk count
+  const size_t u08_cnt = ct_len % 4;  // remaining 8 -bit chunk count
+
   // line 1 of step 1; compute decrypted bits
   //
   // also see step 3 of algorithm defined in section 1.3.5
-  for (size_t i = 0; i < ct_len; i++) {
-    const uint8_t byte = cipher[i];
+  for (size_t i = 0; i < u32_cnt; i++) {
+    const uint32_t enc = from_be_bytes(cipher + (i << 2));
+    uint32_t dec = 0; // recover 32 plain text bits
 
-    const bool p0 = bit_at<0>(byte);
-    const bool ks0 = state_update_128(state, p0, true, false);
-    state[292] ^= ks0;        // update state with decrypted bit
-    const bool c0 = ks0 ^ p0; // decrypted bit
+    state_update_128(state, enc, &dec, MAX_U32, MIN_U32);
+    to_be_bytes(dec, text + (i << 2));
+  }
 
-    const bool p1 = bit_at<1>(byte);
-    const bool ks1 = state_update_128(state, p1, true, false);
-    state[292] ^= ks1;        // update state with decrypted bit
-    const bool c1 = ks1 ^ p1; // decrypted bit
-
-    const bool p2 = bit_at<2>(byte);
-    const bool ks2 = state_update_128(state, p2, true, false);
-    state[292] ^= ks2;        // update state with decrypted bit
-    const bool c2 = ks2 ^ p2; // decrypted bit
-
-    const bool p3 = bit_at<3>(byte);
-    const bool ks3 = state_update_128(state, p3, true, false);
-    state[292] ^= ks3;        // update state with decrypted bit
-    const bool c3 = ks3 ^ p3; // decrypted bit
-
-    const bool p4 = bit_at<4>(byte);
-    const bool ks4 = state_update_128(state, p4, true, false);
-    state[292] ^= ks4;        // update state with decrypted bit
-    const bool c4 = ks4 ^ p4; // decrypted bit
-
-    const bool p5 = bit_at<5>(byte);
-    const bool ks5 = state_update_128(state, p5, true, false);
-    state[292] ^= ks5;        // update state with decrypted bit
-    const bool c5 = ks5 ^ p5; // decrypted bit
-
-    const bool p6 = bit_at<6>(byte);
-    const bool ks6 = state_update_128(state, p6, true, false);
-    state[292] ^= ks6;        // update state with decrypted bit
-    const bool c6 = ks6 ^ p6; // decrypted bit
-
-    const bool p7 = bit_at<7>(byte);
-    const bool ks7 = state_update_128(state, p7, true, false);
-    state[292] ^= ks7;        // update state with decrypted bit
-    const bool c7 = ks7 ^ p7; // decrypted bit
-
-    // from 8 decrypted bits prepare single deciphered byte
-    const uint8_t enc = static_cast<uint8_t>(static_cast<uint8_t>(c7) << 7) |
-                        static_cast<uint8_t>(static_cast<uint8_t>(c6) << 6) |
-                        static_cast<uint8_t>(static_cast<uint8_t>(c5) << 5) |
-                        static_cast<uint8_t>(static_cast<uint8_t>(c4) << 4) |
-                        static_cast<uint8_t>(static_cast<uint8_t>(c3) << 3) |
-                        static_cast<uint8_t>(static_cast<uint8_t>(c2) << 2) |
-                        static_cast<uint8_t>(static_cast<uint8_t>(c1) << 1) |
-                        static_cast<uint8_t>(c0);
-
-    // write 8 decrypted bits to allocated memory
-    text[i] = enc;
+  for (size_t i = 0; i < u08_cnt; i++) {
+    state_update_128(state,
+                     cipher[(u32_cnt << 2) + i],
+                     text + (u32_cnt << 2) + i,
+                     MAX_U8,
+                     MIN_U8);
   }
 
   // line 2 of step 1; append single `1` -bit
-  state_update_128(state, true, true, false);
+  state_update_128(state, 1u, MAX_U32, MIN_U32);
 
   // line 3 of step 1; append 255 `0` -bits
-  for (size_t i = 1; i < 128; i++) {
-    state_update_128(state, false, true, false);
+  for (size_t i = 0; i < 4; i++) {
+    state_update_128(state, 0u, MAX_U32, MIN_U32);
   }
 
-  for (size_t i = 128; i < 256; i++) {
-    state_update_128(state, false, false, false);
+  for (size_t i = 4; i < 8; i++) {
+    state_update_128(state, 0u, MIN_U32, MIN_U32);
   }
 }
 
-// Finalize Acorn-128, which generates authentication tag; this is result of
-// authenticated encryption process & it also helps in conducting verified
-// decryption
+// Finalize Acorn-128, which generates 128 -bit authentication tag; this is
+// result of authenticated encryption process & it also helps in conducting
+// verified decryption
 //
 // See algorithm defined in section 1.3.6 of Acorn specification
 // https://competitions.cr.yp.to/round3/acornv3.pdf
 static inline void
-finalize(bool* const __restrict state, uint8_t* const __restrict tag)
+finalize(uint64_t* const __restrict state, uint8_t* const __restrict tag)
 {
-  for (size_t i = 0; i < 640; i++) {
-    state_update_128(state, false, true, true);
+  for (size_t i = 0; i < 20; i++) {
+    state_update_128(state, 0u, MAX_U32, MAX_U32);
   }
 
   // take last 128 keystream bits & interpret it as authentication tag
-  for (size_t i = 0; i < 16; i++) {
-    // compute 8 authentication tag bits; do it 16 times;
-    // making 128 -bit authentication tag
-    const bool b0 = state_update_128(state, false, true, true);
-    const bool b1 = state_update_128(state, false, true, true);
-    const bool b2 = state_update_128(state, false, true, true);
-    const bool b3 = state_update_128(state, false, true, true);
-    const bool b4 = state_update_128(state, false, true, true);
-    const bool b5 = state_update_128(state, false, true, true);
-    const bool b6 = state_update_128(state, false, true, true);
-    const bool b7 = state_update_128(state, false, true, true);
-
-    // authentication tag byte
-    const uint8_t t_byte = static_cast<uint8_t>(static_cast<uint8_t>(b7) << 7) |
-                           static_cast<uint8_t>(static_cast<uint8_t>(b6) << 6) |
-                           static_cast<uint8_t>(static_cast<uint8_t>(b5) << 5) |
-                           static_cast<uint8_t>(static_cast<uint8_t>(b4) << 4) |
-                           static_cast<uint8_t>(static_cast<uint8_t>(b3) << 3) |
-                           static_cast<uint8_t>(static_cast<uint8_t>(b2) << 2) |
-                           static_cast<uint8_t>(static_cast<uint8_t>(b1) << 1) |
-                           static_cast<uint8_t>(b0);
-
-    tag[i] = t_byte;
+  for (size_t i = 0; i < 4; i++) {
+    const uint32_t ks = state_update_128(state, 0u, MAX_U32, MAX_U32);
+    to_be_bytes(ks, tag + (i << 2));
   }
 }
 

--- a/include/acorn_utils.hpp
+++ b/include/acorn_utils.hpp
@@ -47,7 +47,9 @@ from_be_bytes(const uint8_t* const __restrict bytes)
 static inline void
 to_be_bytes(const uint32_t word, uint8_t* const __restrict bytes)
 {
+#if defined(__clang__)
 #pragma unroll 4
+#endif
   for (size_t i = 0; i < 4; i++) {
     bytes[i] = static_cast<uint8_t>(word >> ((3u - i) << 3));
   }


### PR DESCRIPTION
Adding support for processing 32 -bits in parallel, which results in much faster encryption/ decryption. 

See benchmark results diff [here](https://github.com/itzmeanjan/acorn/commit/a251158b382503fa8728040d26351bede47559da?diff=unified#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L116-R143) ( ~48x improvement ! )